### PR TITLE
Add missing require of rspec/core

### DIFF
--- a/lib/rspec/rails/mocha.rb
+++ b/lib/rspec/rails/mocha.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext'
 require 'active_model'
+require 'rspec/core'
 
 module RSpec
   module Rails


### PR DESCRIPTION
mocha.rb calls `RSpec.configure` so it's good to _not_ assume that rspec was already required and actually require it there. I just had a problem where my rails app was blowing up with "undefined method `configure' for RSpec:Module"
