### PR TITLE
changes to allow for composite primary key gem compatibility

### DIFF
--- a/lib/rspec/rails/mocha.rb
+++ b/lib/rspec/rails/mocha.rb
@@ -190,9 +190,17 @@ EOM
           m.extend ActiveModelStubExtensions
           if defined?(ActiveRecord) && model_class < ActiveRecord::Base
             m.extend ActiveRecordStubExtensions
-            primary_key = model_class.primary_key.to_sym
-            stubs = stubs.reverse_merge(primary_key => next_id)
-            stubs = stubs.reverse_merge(:persisted? => !!stubs[primary_key])
+            unless defined?(model_class.composite?) && model_class.composite? 
+	       primary_key = model_class.primary_key.to_sym
+	       stubs = stubs.reverse_merge(primary_key => next_id)
+               stubs = stubs.reverse_merge(:persisted? => !!stubs[primary_key])
+            else
+               model_class.primary_key.each do |cpk_column|
+                 cpk_column = cpk_column.to_sym
+                 stubs = stubs.reverse_merge(cpk_column => next_id)
+                 stubs = stubs.reverse_merge(:persisted? => !!stubs[cpk_column])
+               end
+            end
           else
             stubs = stubs.reverse_merge(:id => next_id)
             stubs = stubs.reverse_merge(:persisted? => !!stubs[:id])


### PR DESCRIPTION
I believe this is consistent with your reply from a few weeks back regarding infusing the changes for cpk into your existing functionality (although I'm not entirely sure I comprehend what you're doing there as the next_id seems completely abstract).  This change works in my code.  Your tests in /spec are passing locally, but there's nothing testing explicitly for a cpk model and it looks like changes to check for that would be pretty invasive.  
